### PR TITLE
Add support for passing a database URL and other PostgreSQL options

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ module.exports = {
 }
 ```
 
+Optionally, you can specify a database url by specifying a `connectionString`.
+
 To install the necessary database tables, run `db:migrate`. You can also destroy the database by running `db:destroy`.
 
 ## Storage

--- a/src/db/pgsql.js
+++ b/src/db/pgsql.js
@@ -5,14 +5,37 @@ var utils = require('../utils')
 var pg = require('pg')
 
 function createPostgresDb(options = {}) {
+  function parseConfig() {
+    var config = {};
+
+    if (options.connectionString != undefined) {
+      config.connectionString = options.connectionString;
+    } else {
+      config.user     = options.user;
+      config.host     = options.host || 'localhost';
+      config.database = options.database;
+      config.password = options.password;
+      config.port     = options.port || 5432;
+    }
+
+    if (options.ssl != undefined) {
+      config.ssl = options.ssl;
+    }
+
+    if (options.types != undefined) {
+      config.types = options.types;
+    }
+
+    if (options.statement_timeout != undefined) {
+      config.statement_timeout = options.statement_timeout;
+    }
+
+    return config;
+  };
+
+
   return function (pdfBotConfiguration) {
-    var db = new pg.Client({
-      user: options.user,
-      host: options.host || 'localhost',
-      database: options.database,
-      password: options.password,
-      port: options.port || 5432,
-    })
+    var db = new pg.Client(parseConfig());
     db.connect()
 
     var createDbMethod = function (func) {


### PR DESCRIPTION
When running with [PostgreSQL on Heroku](https://devcenter.heroku.com/articles/heroku-postgresql#connecting-in-node-js), among other postgres providers, the connection parameters are provided as a URL string. The pg package supports this, it's just a matter of passing it through the pdf-bot config.

Additionally, this PR adds support for the other possible `pg` [client options](https://node-postgres.com/api/client).