### PR TITLE
Upgrade html-pdf-chrome to v0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-bot",
-  "version": "0.5.4",
+  "version": "0.5.3",
   "author": "Esben Petersen <esbenspetersen@gmail.com>",
   "homepage": "https://github.com/esbenp/pdf-bot",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "commander": "^2.11.0",
     "debug": "^2.6.8",
     "express": "^4.15.3",
-    "html-pdf-chrome": "^0.2.0",
+    "html-pdf-chrome": "^0.4.2",
     "lodash.chunk": "^4.2.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.6.0",


### PR DESCRIPTION
html-pdf-chrome's release of v0.4.2 [fixes a bug](westy92/html-pdf-chrome#115) that causes pdf-bot to hang when processing if the server requested is unresponsive due to a network error.